### PR TITLE
Fix error that would prevent webhook usage.

### DIFF
--- a/modules/github.py
+++ b/modules/github.py
@@ -36,7 +36,7 @@ class Module(ModuleManager.BaseModule):
     @utils.hook("api.post.github")
     def github(self, event):
         payload = event["data"].decode("utf8")
-        if event["headers"]["content-type"] == FORM_ENCODED:
+        if event["headers"]["Content-Type"] == FORM_ENCODED:
             payload = urllib.parse.parse_qs(urllib.parse.unquote(payload)
                 )["payload"][0]
         data = json.loads(payload)


### PR DESCRIPTION
This changes the key 'content-type' to 'Content-Type', which is the proper capitalization, in order to ensure webhooks continue to work regardless of the content-type.