### PR TITLE
ensure that non-url characters not separated by whitespace aren't consumed

### DIFF
--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -4,7 +4,7 @@ import json as _json
 import bs4, netifaces, requests
 from src import utils
 
-REGEX_URL = re.compile("https?://\S+", re.I)
+REGEX_URL = re.compile("https?://[A-Z0-9{}]+".format(re.escape("-._~:/?#[]@!$&'()*+,;=")), re.I)
 
 USER_AGENT = ("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36")

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -4,7 +4,7 @@ import json as _json
 import bs4, netifaces, requests
 from src import utils
 
-REGEX_URL = re.compile("https?://[A-Z0-9{}]+".format(re.escape("-._~:/?#[]@!$&'()*+,;=")), re.I)
+REGEX_URL = re.compile("https?://[A-Z0-9{}]+".format(re.escape("-._~:/%?#[]@!$&'()*+,;=")), re.I)
 
 USER_AGENT = ("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/49.0.2623.87 Safari/537.36")


### PR DESCRIPTION
I'm not sure how you want to handle unicode characters though, because technically unicode characters aren't valid in URLs, but are encoded via punycode - but this may not be what you intended..? Are there any tests we can perform.

The reason for this change was that I noticed that the URL shortener tried to shorten the URL `https://tilde.news/s/tclp8i>`, from a posted message of `03:10 <BabiliBot> [links] GNU Guix 1.0.0 released — 2019 — Blog — GNU Guix (posted by cmccabe) <https://tilde.news/s/tclp8i>`. This led to a 404 of course.