### PR TITLE
Revert "added license info"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -290,8 +290,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Bitbot IRC bot
-    Copyright (C) 2019  jesopo, https://github.com/jesopo/bitbot
+    {description}
+    Copyright (C) {year}  {fullname}
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -312,7 +312,7 @@ Also add information on how to contact you by electronic and paper mail.
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) 2019 jesopo
+    Gnomovision version 69, Copyright (C) year name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
Reverts jesopo/bitbot#53
---
The changed section is for "_How to Apply These Terms to Your New Programs_", and the document itself says that changing it is not allowed. This needs reverted.