### PR TITLE
bug fix: ISO8601_PARSE var in src/utils/__init__.py stops modules from behaving correctly if they use it

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -5,7 +5,7 @@ class Direction(enum.Enum):
     Send = 0
     Recv = 1
 
-ISO8601_PARSE = "%Y-%m-%dT%H:%M:%S%z"
+ISO8601_PARSE = "%Y-%m-%dT%H:%M:%SZ"
 ISO8601_PARSE_MICROSECONDS = "%Y-%m-%dT%H:%M:%S.%f%z"
 DATETIME_HUMAN = "%Y/%m/%d %H:%M:%S"
 


### PR DESCRIPTION
applies to modules that use the "ISO8601_PARSE" variable