### PR TITLE
Improves sentence processing for karma

### DIFF
--- a/modules/karma.py
+++ b/modules/karma.py
@@ -8,7 +8,7 @@ from src import EventManager, ModuleManager, utils
 WORD_STOP = [",", ":"]
 KARMA_DELAY_SECONDS = 3
 
-REGEX_KARMA = re.compile(r'(?:\((.+?)\)|(\S+))(\+\+|--)(\s+|$)')
+REGEX_KARMA = re.compile(r'(?:\(([^)]+)\)|(\S+))(\+\+|--)(\s+|$)')
 
 @utils.export("channelset", utils.BoolSetting("karma-pattern",
     "Enable/disable parsing ++/-- karma format"))
@@ -84,9 +84,9 @@ class Module(ModuleManager.BaseModule):
 
         # There are two possible match groups, an arbitrary length text inside (), or a single word followed by ++/--
         # group 1 is the former, group 2 is the latter
-        target = event["match"].group(1) if event["match"].group(1) else event["match"].group(2)
+        target = event["match"].group(1) or event["match"].group(2)
         target = target.strip().rstrip("".join(WORD_STOP)) # Strips "," " " or ":" from target
-        
+
         # if we have a target...
         if target:
             success, message = self._karma(event["server"], event["user"],


### PR DESCRIPTION
Changes the matching regex to grab arbitrary text between ()
for giving (or taking away) karma. Still supports single words
followed by ++/--, including usernames, and strips "," or ":"
characters from the end if a single-word match.

ex. `(some sentence to give karma to)++` -> `[Karma] some sentence to give karma to now has 1  karma`

ex. `ngp:++` -> `[Karma] ngp now has 200 karma`

The bot this is adapted from keeps track of which user gives what text karma, and does some fun things with "text+-" where it does both a ++ and -- operation and counts both. I didn't look to see if that kind of info is being tracked, but it could theoretically be added in if wanted.

It might also be worth looking into a character limit for `target`.