### PR TITLE
Adjust line splitpoints to word boundaries

### DIFF
--- a/modules/commands/outs.py
+++ b/modules/commands/outs.py
@@ -64,8 +64,7 @@ class Out(object):
 
             sent_line = self.server.send(line)
 
-    @staticmethod
-    def _adjust_to_word_boundaries(left, right):
+    def _adjust_to_word_boundaries(self, left, right):
         if right[0] == WORD_BOUNDARY:
             return left, right
 

--- a/modules/commands/outs.py
+++ b/modules/commands/outs.py
@@ -4,6 +4,7 @@ from src import utils
 STR_MORE = " (more...)"
 STR_MORE_LEN = len(STR_MORE.encode("utf8"))
 STR_CONTINUED = "(...continued) "
+WORD_BOUNDARY = ' '
 
 class Out(object):
     def __init__(self, server, module_name, target, target_str, tags):
@@ -54,12 +55,26 @@ class Out(object):
                 margin=STR_MORE_LEN)
 
             if truncated:
+                valid, truncated = self._adjust_to_word_boundaries(valid, truncated)
+
                 line = utils.irc.parse_line(valid+STR_MORE)
                 self._text = "%s%s" % (STR_CONTINUED, truncated)
             else:
                 self._text = ""
 
             sent_line = self.server.send(line)
+
+    @staticmethod
+    def _adjust_to_word_boundaries(left, right):
+        if right[0] == WORD_BOUNDARY:
+            return left, right
+
+        parts = left.rsplit(WORD_BOUNDARY, 1)
+
+        if len(parts) != 2:
+            return left, right
+
+        return parts[0], parts[1] + right
 
     def _default_prefix(self, s: str):
         return s


### PR DESCRIPTION
This change shifts the split point of lines to match
word boundaries (currently only ' ').
In case no word boundary is found, the original splitpoint
is left intact.

Closes #159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jesopo/bitbot/173)
<!-- Reviewable:end -->
