### PR TITLE
Fix empty fediverse display names

### DIFF
--- a/modules/fediverse/ap_actor.py
+++ b/modules/fediverse/ap_actor.py
@@ -17,9 +17,7 @@ class Actor(object):
         if response.code == 200:
             response = response.json()
             self.username = response["preferredUsername"]
-            self.display_name = response.get("name", self.username)
-            if not self.display_name:
-                self.display_name = self.username
+            self.display_name = response.get("name") or self.username
             self.inbox = Inbox(response["inbox"])
             self.outbox = Outbox(response["outbox"])
             self.followers = response["followers"]

--- a/modules/fediverse/ap_actor.py
+++ b/modules/fediverse/ap_actor.py
@@ -18,6 +18,8 @@ class Actor(object):
             response = response.json()
             self.username = response["preferredUsername"]
             self.display_name = response.get("name", self.username)
+            if not self.display_name:
+                self.display_name = self.username
             self.inbox = Inbox(response["inbox"])
             self.outbox = Outbox(response["outbox"])
             self.followers = response["followers"]


### PR DESCRIPTION
Specifically, botsin.space (for sure) returns a display name of `""` unless you set one. Since that's not meaningful, I just added a check to replace the display name with the username if the display name is empty.