### PR TITLE
fix shorturl.py

### DIFF
--- a/modules/shorturl.py
+++ b/modules/shorturl.py
@@ -48,9 +48,11 @@ class Module(ModuleManager.BaseModule):
         shortener_name = None
         if context:
             shortener_name = context.get_setting("url-shortener",
-                server.get_setting("url-shortener", "bitly"))
+                server.get_setting("url-shortener",
+                self.bot.get_setting("url-shortener", "bitly")))
         else:
-            shortener_name = server.get_setting("url-shortener", "bitly")
+            shortener_name = server.get_setting("url-shortener",
+                self.bot.get_setting("url-shortener", "bitly"))
 
         if shortener_name == None:
             return url


### PR DESCRIPTION
this module provides a botset export but doesn't check that
setting later when looking up configured shorteners

check bot_settings if context and server values are not set