### PR TITLE
add ban-enforce-max config option

### DIFF
--- a/modules/ban_enforce.py
+++ b/modules/ban_enforce.py
@@ -4,6 +4,8 @@ REASON = "User is banned from this channel"
 
 @utils.export("channelset", utils.BoolSetting("ban-enforce",
     "Whether or not to parse new bans and kick who they affect"))
+@utils.export("channelset", utils.IntSetting("ban-enforce-max",
+    "Do not enforce ban if the ban effects more than this many users. Default is half of total channel users."))
 class Module(ModuleManager.BaseModule):
     @utils.hook("received.mode.channel")
     def on_mode(self, event):
@@ -15,13 +17,19 @@ class Module(ModuleManager.BaseModule):
                     bans.append(arg)
 
             if bans:
+                affected = 0
                 umasks = {u.hostmask(): u for u in event["channel"].users}
+                defaultmax = len(event["channel"].users) // 2
+                realmax = event["channel"].get_setting("ban-enforce-max", defaultmax)
                 for ban in bans:
                     mask = utils.irc.hostmask_parse(ban)
                     matches = list(utils.irc.hostmask_match_many(
                         umasks.keys(), mask))
                     for match in matches:
+                        affected = affected + 1
                         kicks.add(umasks[match])
             if kicks:
+                if affected > realmax:
+                    return
                 nicks = [u.nickname for u in kicks]
                 event["channel"].send_kicks(sorted(nicks), REASON)

--- a/modules/ban_enforce.py
+++ b/modules/ban_enforce.py
@@ -16,11 +16,12 @@ class Module(ModuleManager.BaseModule):
                 if mode[0] == "+" and mode[1] == "b":
                     bans.append(arg)
 
+            affected = 0
+            defaultmax = len(event["channel"].users) // 2
+            realmax = event["channel"].get_setting("ban-enforce-max", defaultmax)
+            
             if bans:
-                affected = 0
                 umasks = {u.hostmask(): u for u in event["channel"].users}
-                defaultmax = len(event["channel"].users) // 2
-                realmax = event["channel"].get_setting("ban-enforce-max", defaultmax)
                 for ban in bans:
                     mask = utils.irc.hostmask_parse(ban)
                     matches = list(utils.irc.hostmask_match_many(


### PR DESCRIPTION
Add a config setting to not enforce bans that would affect more than a specified number of people (default is set to more than half of the users in the channel). This is useful in case a chanop accidentally bans a wide mask (like `*!*@*`) so that BitBot would not kick the entire channel.