### PR TITLE
General Improvements to the Wikipedia Module

### DIFF
--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -10,7 +10,8 @@ class Module(ModuleManager.BaseModule):
     def listify(self, items):
         if type(items) != list:
            items = list(items)
-        return len(items) > 1 and ', '.join(items[:-1]) + ', or ' + items[-1] or items and items[0] or ''
+        
+        return len(items) > 2 and ', '.join(items[:-1]) + ', or ' + items[-1] or len(items) > 1 and items[0] + ' or ' + items[1] or items and items[0] or ''
 
     def disambig(self, title):
         api = utils.http.request(URL_WIKIPEDIA, get_params={

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -17,7 +17,9 @@ class Module(ModuleManager.BaseModule):
             "action": "parse", "format": "json", "page": title, "prop": "wikitext"}).json()
         if api:
             text = api['parse']['wikitext']['*']
-            links = re.findall('\* \[\[(.*)\]\]', text)
+            links = []
+            links.extend(re.findall('\* \[\[(.*)\]\]', text))
+            links.extend(re.findall('\*\[\[(.*)\]\]', text))
             disambigs = []
             if links:
                 for link in links:

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -40,7 +40,6 @@ class Module(ModuleManager.BaseModule):
     @utils.kwarg("help", "Get information from wikipedia")
     @utils.spec("!<term>lstring")
     def wikipedia(self, event):
-        print(event["spec"][0])
         page = utils.http.request(URL_WIKIPEDIA, get_params={
             "action": "query", "prop": "extracts|info", "inprop": "url",
             "titles": event["spec"][0], "exintro": "", "explaintext": "",

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -88,9 +88,9 @@ class Module(ModuleManager.BaseModule):
     @utils.spec("!<term>lstring")
     def wikipedia(self, event):
         page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["target"].get_setting("wikipedia-lang", "en")), get_params={
-            "action": "query", "prop": "extracts|info", "inprop": "url",
+            "action": "query", "prop": "extracts|info|pageprops", "inprop": "url",
             "titles": event["spec"][0], "exintro": "", "explaintext": "",
-            "exchars": "500", "redirects": "", "format": "json"}).json()
+            "exchars": "500", "redirects": "", "format": "json", "pageprops": "disambiguation"}).json()
         if page:
             pages = page["query"]["pages"]
             article = list(pages.items())[0][1]
@@ -99,7 +99,7 @@ class Module(ModuleManager.BaseModule):
                 title = article["title"]
                 info = utils.parse.line_normalise(article["extract"])
                 url = article["fullurl"].replace(' ', '_')
-                if 'may refer to' in info:
+                if "pageprops" in article and "disambiguation" in article["pageprops"]:
                     event["stdout"].write("%s %s" % (self.disambig(title, event), url))
                 else:
                     event["stdout"].write("%s: %s - %s" % (title, info, url))

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -5,6 +5,33 @@ from src import ModuleManager, utils
 URL_WIKIPEDIA = "https://en.wikipedia.org/w/api.php"
 
 class Module(ModuleManager.BaseModule):
+    def listify(self, items):
+        if type(items) != list:
+           items = list(items)
+        return len(items) > 1 and ', '.join(items[:-1]) + ', or ' + items[-1] or items and items[0] or ''
+    
+    def disambig(self, title):
+        api = utils.http.request(URL_WIKIPEDIA, get_params={
+            "action": "parse", "format": "json", "page": page, "prop": "wikitext"}).json()
+        if api:
+            text = api['parse']['wikitext']['*']
+            links = re.findall('\* \[\[(.*)\]\]', text)
+            disambigs = []
+            if links:
+                for link in links:
+                    # parse through the wikitext adventure
+                    if '|' in link:
+                        d = link.split('|')[1]
+                    else:
+                        d = link
+                    d = d.replace('\'', '').replace('\'', '').replace('"', '')
+                    disambigs.append(d)
+            else:
+                return 'Unable to parse disambiguation page. You may view the page at'
+            if len(disambigs) > 15:
+                return 'Sorry, but this page is too ambiguous. You may view the page at'
+            else:
+                return '%s could mean %s -' % (title, self.listify(disambigs))
     @utils.hook("received.command.wi", alias_of="wiki")
     @utils.hook("received.command.wiki", alias_of="wikipedia")
     @utils.hook("received.command.wikipedia")
@@ -24,7 +51,8 @@ class Module(ModuleManager.BaseModule):
                 title = article["title"]
                 info = utils.parse.line_normalise(article["extract"])
                 url = article["fullurl"]
-
+                if 'may refer to' in info:
+                    event["stdout.write("%s %s" % (self.disambig(title), url)
                 event["stdout"].write("%s: %s - %s" % (title, info, url))
             else:
                 event["stderr"].write("No results found")

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -29,12 +29,8 @@ class Module(ModuleManager.BaseModule):
         return len(items) > 2 and ', '.join(items[:-1]) + ', or ' + items[-1] or len(items) > 1 and items[0] + ' or ' + items[1] or items and items[0] or ''
 
     def disambig(self, title, event):
-        if not str(event["target"]).startswith('#'):
-            api = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["target"].get_setting("wikipedia-lang", "en")), get_params={
-                "action": "parse", "format": "json", "page": title, "prop": "wikitext"}).json()
-        else:
-            api = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["channel"].get_setting("wikipedia-lang", "en")), get_params={
-                "action": "parse", "format": "json", "page": title, "prop": "wikitext"}).json()
+        api = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["target"].get_setting("wikipedia-lang", "en")), get_params={
+            "action": "parse", "format": "json", "page": title, "prop": "wikitext"}).json()
         if api:
             text = api['parse']['wikitext']['*']
             links = []
@@ -52,7 +48,7 @@ class Module(ModuleManager.BaseModule):
                     disambigs.append(d)
             else:
                 return 'Unable to parse disambiguation page. You may view the page at'
-            if len(disambigs) > event["channel"].get_setting("wikipedia-disambig-max", 10):
+            if len(disambigs) > event["target"].get_setting("wikipedia-disambig-max", 10):
                 return 'Sorry, but this page is too ambiguous. You may view the page at'
             else:
                 return '%s could mean %s -' % (title, self.listify(disambigs))
@@ -65,7 +61,7 @@ class Module(ModuleManager.BaseModule):
         wikilink = re.search("\[\[(.*)\]\]", event["message"])
         if wikilink:
             page = wikilink.group(1)
-        page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["channel"].get_setting("wikipedia-lang", "en")), get_params={
+        page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["target"].get_setting("wikipedia-lang", "en")), get_params={
             "action": "query", "prop": "extracts|info", "inprop": "url",
             "titles": page, "exintro": "", "explaintext": "",
             "exchars": "500", "redirects": "", "format": "json"}).json()
@@ -94,16 +90,11 @@ class Module(ModuleManager.BaseModule):
     @utils.kwarg("help", "Get information from wikipedia")
     @utils.spec("!<term>lstring")
     def wikipedia(self, event):
-        if not str(event["target"]).startswith('#'):
-            page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["target"].get_setting("wikipedia-lang", "en")), get_params={
-                "action": "query", "prop": "extracts|info", "inprop": "url",
-                "titles": event["spec"][0], "exintro": "", "explaintext": "",
-                "exchars": "500", "redirects": "", "format": "json"}).json()
-        else:
-            page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["channel"].get_setting("wikipedia-lang", "en")), get_params={
-                "action": "query", "prop": "extracts|info", "inprop": "url",
-                "titles": event["spec"][0], "exintro": "", "explaintext": "",
-                "exchars": "500", "redirects": "", "format": "json"}).json()
+#        if not str(event["target"]).startswith('#'):
+        page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["target"].get_setting("wikipedia-lang", "en")), get_params={
+            "action": "query", "prop": "extracts|info", "inprop": "url",
+            "titles": event["spec"][0], "exintro": "", "explaintext": "",
+            "exchars": "500", "redirects": "", "format": "json"}).json()
         if page:
             pages = page["query"]["pages"]
             article = list(pages.items())[0][1]

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -13,6 +13,9 @@ URL_WIKIPEDIA = "https://$lang.wikipedia.org/w/api.php"
     "Choose which language to use for Wikipedia",
     example="en"))
 
+@utils.export("channelset", utils.BoolSetting("wikipedia-autolink",
+    "Auto-translate to wiki-links"))
+
 class Module(ModuleManager.BaseModule):
     def listify(self, items):
         if type(items) != list:
@@ -44,6 +47,38 @@ class Module(ModuleManager.BaseModule):
                 return 'Sorry, but this page is too ambiguous. You may view the page at'
             else:
                 return '%s could mean %s -' % (title, self.listify(disambigs))
+    
+    
+    @utils.hook("received.message.channel")
+    def handle_chanmsg(self, event):
+        if not event["channel"].get_setting("wikipedia-autolink", False):
+            return
+        wikilink = re.search("\[\[(.*)\]\]", event["message"])
+        if wikilink:
+            page = wikilink.group(1)
+        page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["channel"].get_setting("wikipedia-lang", "en")), get_params={
+            "action": "query", "prop": "extracts|info", "inprop": "url",
+            "titles": page, "exintro": "", "explaintext": "",
+            "exchars": "500", "redirects": "", "format": "json"}).json()
+
+        if page:
+            pages = page["query"]["pages"]
+            article = list(pages.items())[0][1]
+            if not "missing" in article:
+                title, info = article["title"], article["extract"]
+                title = article["title"]
+                info = utils.parse.line_normalise(article["extract"])
+                url = article["fullurl"]
+                if 'may refer to' in info:
+                    event["channel"].send_message("%s %s" % (self.disambig(title, event), url))
+                else:
+                    event["channel"].send_message("%s: %s - %s" % (title, info, url))
+            else:
+                event["channel"].send_message("No results found")
+        else:
+            raise utils.EventResultsError()
+    
+    
     @utils.hook("received.command.wi", alias_of="wiki")
     @utils.hook("received.command.wiki", alias_of="wikipedia")
     @utils.hook("received.command.wikipedia")

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -4,10 +4,14 @@ from src import ModuleManager, utils
 import re
 import json
 
-URL_WIKIPEDIA = "https://en.wikipedia.org/w/api.php"
+URL_WIKIPEDIA = "https://$lang.wikipedia.org/w/api.php"
 
 @utils.export("channelset", utils.IntSetting("wikipedia-disambig-max",
     "Set the number disambiguation pages to show in a message"))
+
+@utils.export("channelset", utils.Setting("wikipedia-lang",
+    "Choose which language to use for Wikipedia",
+    example="en"))
 
 class Module(ModuleManager.BaseModule):
     def listify(self, items):
@@ -17,7 +21,7 @@ class Module(ModuleManager.BaseModule):
         return len(items) > 2 and ', '.join(items[:-1]) + ', or ' + items[-1] or len(items) > 1 and items[0] + ' or ' + items[1] or items and items[0] or ''
 
     def disambig(self, title, event):
-        api = utils.http.request(URL_WIKIPEDIA, get_params={
+        api = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["channel"].get_setting("wikipedia-lang", "en")), get_params={
             "action": "parse", "format": "json", "page": title, "prop": "wikitext"}).json()
         if api:
             text = api['parse']['wikitext']['*']
@@ -46,7 +50,7 @@ class Module(ModuleManager.BaseModule):
     @utils.kwarg("help", "Get information from wikipedia")
     @utils.spec("!<term>lstring")
     def wikipedia(self, event):
-        page = utils.http.request(URL_WIKIPEDIA, get_params={
+        page = utils.http.request(URL_WIKIPEDIA.replace('$lang', event["channel"].get_setting("wikipedia-lang", "en")), get_params={
             "action": "query", "prop": "extracts|info", "inprop": "url",
             "titles": event["spec"][0], "exintro": "", "explaintext": "",
             "exchars": "500", "redirects": "", "format": "json"}).json()

--- a/modules/wikipedia.py
+++ b/modules/wikipedia.py
@@ -1,6 +1,8 @@
 #--depends-on commands
 
 from src import ModuleManager, utils
+import re
+import json
 
 URL_WIKIPEDIA = "https://en.wikipedia.org/w/api.php"
 
@@ -9,10 +11,10 @@ class Module(ModuleManager.BaseModule):
         if type(items) != list:
            items = list(items)
         return len(items) > 1 and ', '.join(items[:-1]) + ', or ' + items[-1] or items and items[0] or ''
-    
+
     def disambig(self, title):
         api = utils.http.request(URL_WIKIPEDIA, get_params={
-            "action": "parse", "format": "json", "page": page, "prop": "wikitext"}).json()
+            "action": "parse", "format": "json", "page": title, "prop": "wikitext"}).json()
         if api:
             text = api['parse']['wikitext']['*']
             links = re.findall('\* \[\[(.*)\]\]', text)
@@ -38,6 +40,7 @@ class Module(ModuleManager.BaseModule):
     @utils.kwarg("help", "Get information from wikipedia")
     @utils.spec("!<term>lstring")
     def wikipedia(self, event):
+        print(event["spec"][0])
         page = utils.http.request(URL_WIKIPEDIA, get_params={
             "action": "query", "prop": "extracts|info", "inprop": "url",
             "titles": event["spec"][0], "exintro": "", "explaintext": "",
@@ -52,10 +55,10 @@ class Module(ModuleManager.BaseModule):
                 info = utils.parse.line_normalise(article["extract"])
                 url = article["fullurl"]
                 if 'may refer to' in info:
-                    event["stdout.write("%s %s" % (self.disambig(title), url)
-                event["stdout"].write("%s: %s - %s" % (title, info, url))
+                    event["stdout"].write("%s %s" % (self.disambig(title), url))
+                else:
+                    event["stdout"].write("%s: %s - %s" % (title, info, url))
             else:
                 event["stderr"].write("No results found")
         else:
             raise utils.EventResultsError()
-


### PR DESCRIPTION
This PR adds a few changes to the way the Wikipedia module works. The Wikipedia module will now:

- Query the first 500 characters of a WP article and return it to IRC (as it has always done)
- Determine if a page is ambiguous and will return the first 10 (can be changed via config) pages it links to. This feature will probably only work on enwiki since the format for disambiguation pages are different across wikis.
- Allow chanops to change the language of Wikipedia that is used when using the module via 'config c'. This can also be changed for users via 'config u'.
- Allow chanops to enable auto wiki links in their channels. For example, if a user types `I want an [[Apple]] to eat`, BitBot will return information about the [apple article](https://en.wikipedia.org/wiki/Apple) on Wikipedia.