### PR TITLE
[Tweets] Fix tweet age calc for TZ!=UTC

### DIFF
--- a/modules/tweets/format.py
+++ b/modules/tweets/format.py
@@ -2,7 +2,7 @@ import datetime, html, time
 from src import utils
 
 def _timestamp(dt):
-    seconds_since = time.time()-dt.timestamp()
+    seconds_since = time.time()-dt.replace(tzinfo=datetime.timezone.utc).timestamp()
     timestamp = utils.datetime.format.to_pretty_since(
         seconds_since, max_units=2)
     return "%s ago" % timestamp


### PR DESCRIPTION
dt is a naive datetime object, so its timezone is assumed to be the system timezone. However, the actual timezone from the API is UTC. Therefore, we need to set tzinfo before doing the calculation. See the note at https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp for more info.

Ideally this would be fixed in tweepy, but there's a report of this on forums from 7 years ago so let's just fix it in BitBot.

This bug found by an anonymous contributor. Thank you 😺!

**Needs testing before merge.**