### PR TITLE
Change example pronouns to neutral pronouns

### DIFF
--- a/modules/pronouns.py
+++ b/modules/pronouns.py
@@ -4,7 +4,7 @@
 from src import ModuleManager, utils
 
 @utils.export("set", utils.Setting("pronouns", "Set your pronouns",
-    example="she/her"))
+    example="they/them"))
 class Module(ModuleManager.BaseModule):
     @utils.hook("received.command.pronouns")
     def pronouns(self, event):


### PR DESCRIPTION
It would be better in my opinion to use neutral pronouns instead of `she/her`.