### PR TITLE
Make karmawho work better

### DIFF
--- a/modules/karma.py
+++ b/modules/karma.py
@@ -17,7 +17,14 @@ class Module(ModuleManager.BaseModule):
     def listify(self, items):
         if type(items) != list:
            items = list(items)
-        return len(items) > 2 and ', '.join(items[:-1]) + ', and ' + items[-1] or len(items) > 1 and items[0] + ' and ' + items[1] or items and items[0] or ''
+        listified = ""
+        if len(items) > 2:
+            listified = ', '.join(items[:-1]) + ', and ' + items[-1]
+        elif len(items) > 1:
+            listified = items[0] + ' and ' + items[1]
+        elif items:
+            listified = items[0]
+        return listified
 
     def _karma_str(self, karma):
         karma_str = str(karma)

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -139,7 +139,6 @@ class Module(ModuleManager.BaseModule):
             reverse=True)
 
         parts = ["%s (%d)" % (n, v) for n, v in karma]
-        print(parts)
         if len(parts) == 0:
             event["stdout"].write("%s has no karma." % target)
             return

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -132,7 +132,7 @@ class Module(ModuleManager.BaseModule):
     @utils.hook("received.command.karmawho")
     @utils.spec("!<target>string")
     def karmawho(self, event):
-        target = event["spec"][0]
+        target = event["server"].irc_lower(event["spec"][0])
         karma = self._get_karma(event["server"], target, True)
         karma = sorted(list(karma.items()),
             key=lambda k: abs(k[1]),

--- a/modules/karma.py
+++ b/modules/karma.py
@@ -14,6 +14,11 @@ REGEX_PARENS = re.compile(r"\(([^)]+)\)(\+\+|--)")
 @utils.export("channelset", utils.BoolSetting("karma-pattern",
     "Enable/disable parsing ++/-- karma format"))
 class Module(ModuleManager.BaseModule):
+    def listify(self, items):
+        if type(items) != list:
+           items = list(items)
+        return len(items) > 2 and ', '.join(items[:-1]) + ', and ' + items[-1] or len(items) > 1 and items[0] + ' and ' + items[1] or items and items[0] or ''
+
     def _karma_str(self, karma):
         karma_str = str(karma)
         if karma < 0:
@@ -134,8 +139,12 @@ class Module(ModuleManager.BaseModule):
             reverse=True)
 
         parts = ["%s (%d)" % (n, v) for n, v in karma]
+        print(parts)
+        if len(parts) == 0:
+            event["stdout"].write("%s has no karma." % target)
+            return
         event["stdout"].write("%s has karma from: %s" %
-            (target, ", ".join(parts)))
+            (target, self.listify(parts)))
 
     def _get_karma(self, server, target, own=False):
         settings = dict(server.get_all_user_settings("karma-%s" % target))


### PR DESCRIPTION
This PR addresses #295 and improves the way karma is listed out

Before:
`[Karma] something has karma from: `
After:
`[Karma] something has no karma`

Before:
`[Karma] something has karma from examknow (3), jess (2), xfnw (1)`
After:
`[Karma] something has karma from examknow (3), jess (2), and xfnw (1)`