### PR TITLE
casefold nickname so sed-sender-only works with capital letters in nick

### DIFF
--- a/modules/sed.py
+++ b/modules/sed.py
@@ -35,7 +35,7 @@ class Module(ModuleManager.BaseModule):
         sed.replace = utils.irc.bold(sed.replace)
 
         if self._closest_setting(event, "sed-sender-only", False):
-            for_user = event["user"].nickname
+            for_user = event["user"].nickname_lower
 
         match_line = None
         match_message = None


### PR DESCRIPTION
this fixes the bug where bitbot would ignore sed of users with Uppercase nicks (eg `Xfnw`) when `sed` and `sed-sender-only` are on