### PR TITLE
Add AS/hostname/buffer lookup to geoip, implement IPinfo command

### DIFF
--- a/docs/bot.conf.example
+++ b/docs/bot.conf.example
@@ -94,3 +94,6 @@ bitly-api-key            =
 
 # https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
 github-token             =
+
+# https://ipinfo.io/account/token
+ipinfo-token             =

--- a/modules/ip_addresses.py
+++ b/modules/ip_addresses.py
@@ -152,10 +152,10 @@ class Module(ModuleManager.BaseModule):
 
                 data  = page["ip"]
                 data += " (%s)" % hostname if hostname else ""
-                data += " | ISP: %s" % page["org"]
-                data += " | Location: %s, %s, %s" % (
-                    page["city"], page["region"], page["country"])
                 data += " (Anycast)" if page.get("anycast", False) == True else ""
+                data += " | City: %s" % page["city"]
+                data += " | Region: %s (%s)" % (page["region"], page["country"])
+                data += " | ISP: %s" % page["org"]
                 data += " | Lon/Lat: %s" % page["loc"]
                 data += " | Timezone: %s" % page["timezone"]
                 event["stdout"].write(data)

--- a/modules/ip_addresses.py
+++ b/modules/ip_addresses.py
@@ -89,17 +89,24 @@ class Module(ModuleManager.BaseModule):
         page = utils.http.request(URL_GEOIP % event["args_split"][0]).json()
         if page:
             if page["status"] == "success":
+                try:
+                    hostname, alias, ips = socket.gethostbyaddr(page["query"])
+                except (socket.herror, socket.gaierror):
+                    pass
+
                 data  = page["query"]
+                if hostname:
+                    data += " (%s)" % hostname
                 data += " | Organisation: %s" % page["org"]
                 data += " | City: %s" % page["city"]
                 data += " | Region: %s (%s)" % (
                     page["regionName"], page["countryCode"])
-                data += " | ISP: %s" % page["isp"]
+                data += " | ISP: %s (%s)" % (page["isp"], page["as"])
                 data += " | Lon/Lat: %s/%s" % (page["lon"], page["lat"])
                 data += " | Timezone: %s" % page["timezone"]
                 event["stdout"].write(data)
             else:
-                event["stderr"].write("No geoip data found")
+                event["stderr"].write("No GeoIP data found")
         else:
             raise utils.EventResultsError()
 


### PR DESCRIPTION
This Pull Request adds AS and hostname lookup to the `geoip` command, and matches `rdns` behaviour in looking in the buffer for IPs if no argument is specified on command execution.

Outside of that, `ipinfo` command was implemented as an alternative IP lookup source. Right now, only GeoIP information can be obtained (since it's what you'd get access to as Anonymous/Free plans), but there's room to implementing other IPinfo endpoints.
It works fine as Anonymous, but you can pass an optional access token via the config with `ipinfo-token`.