### PR TITLE
remove references to `bitbot.dev` from codebase

### DIFF
--- a/src/IRCBot.py
+++ b/src/IRCBot.py
@@ -2,7 +2,7 @@ VERSION: str = ""
 with open("VERSION", "r") as version_file:
     VERSION = "v%s" % version_file.read().strip()
 SOURCE: str = "https://git.io/bitbot"
-URL: str = "https://bitbot.dev"
+URL: str = "https://git.io/bitbot"
 
 import enum, queue, os, queue, select, socket, sys, threading, time, traceback
 import typing, uuid


### PR DESCRIPTION
The bitbot.dev domain has been down since about mid-july and from everything I've heard there are no plans to keep it running. Keeping this in the bot is nothing but confusing to users.