### PR TITLE
Remove support for `git.io` shortening

### DIFF
--- a/modules/git_webhooks/github.py
+++ b/modules/git_webhooks/github.py
@@ -172,15 +172,10 @@ class GitHub(object):
         return list(zip(out, [None]*len(out)))
 
     def _short_url(self, url):
-        self.log.debug("git.io shortening: %s" % url)
-        try:
-            page = utils.http.request("https://git.io", method="POST",
-                post_data={"url": url})
-            return page.headers["Location"]
-        except utils.http.HTTPTimeoutException:
-            self.log.warn(
-                "HTTPTimeoutException while waiting for github short URL", [])
-            return url
+        # TODO: find an alternative to git.io
+        # see https://github.com/jesopo/bitbot/issues/338
+        # ~ examknow 1/19/2022
+        return url
 
     def _iso8601(self, s):
         return utils.datetime.parse.iso8601(s)

--- a/modules/github.py
+++ b/modules/github.py
@@ -47,14 +47,10 @@ class Module(ModuleManager.BaseModule):
         return org, repo, number
 
     def _short_url(self, url):
-        try:
-            page = utils.http.request("https://git.io", method="POST",
-                post_data={"url": url})
-            return page.headers["Location"]
-        except utils.http.HTTPTimeoutException:
-            self.log.warn(
-                "HTTPTimeoutException while waiting for github short URL", [])
-            return url
+        # TODO: find an alternative to git.io
+        # see https://github.com/jesopo/bitbot/issues/338
+        # ~ examknow 1/19/2022
+        return url
 
     def _change_count(self, n, symbol, color):
         return utils.irc.color("%s%d" % (symbol, n), color)+utils.irc.bold("")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 beautifulsoup4  ==4.8.0
 cryptography    >=3.3.2
 dataclasses     ==0.6;python_version<'3.7'
-dnspython       ==1.16.0
-feedparser      ==5.2.1
+dnspython       ==2.0.0
+feedparser      ==6.0.2
 html5lib        ==1.0.1
 isodate         ==0.6.0
 lxml            ==4.6.3

--- a/src/core_modules/ignore.py
+++ b/src/core_modules/ignore.py
@@ -125,7 +125,7 @@ class Module(ModuleManager.BaseModule):
 
     @utils.hook("received.command.serverignore")
     @utils.kwarg("help", "Ignore a command on the current server")
-    @utils.kwarg("permissions", "serverignore")
+    @utils.kwarg("permission", "serverignore")
     @utils.spec("!<command>wordlower")
     def server_ignore(self, event):
         command = event["spec"][0]
@@ -141,7 +141,7 @@ class Module(ModuleManager.BaseModule):
 
     @utils.hook("received.command.serverunignore")
     @utils.kwarg("help", "Unignore a command on the current server")
-    @utils.kwarg("permissions", "serverunignore")
+    @utils.kwarg("permission", "serverunignore")
     @utils.spec("!<command>wordlower")
     def server_unignore(self, event):
         command = event["spec"][0]
@@ -154,4 +154,3 @@ class Module(ModuleManager.BaseModule):
             event["server"].del_setting(setting)
             event["stdout"].write("No longer ignoring '%s' for %s" %
                 (command, str(event["server"])))
-


### PR DESCRIPTION
Intended as a temporary solution for #338 so we can unbreak things that rely on it.