### PR TITLE
urbandictionary: use https

### DIFF
--- a/modules/urbandictionary.py
+++ b/modules/urbandictionary.py
@@ -2,7 +2,7 @@
 
 from src import ModuleManager, utils
 
-URL_URBANDICTIONARY = "http://api.urbandictionary.com/v0/define"
+URL_URBANDICTIONARY = "https://api.urbandictionary.com/v0/define"
 
 class Module(ModuleManager.BaseModule):
     _name = "UrbanDictionary"


### PR DESCRIPTION
Urban Dictionary appears to have removed support for using plaintext