### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ PySocks         ==1.7.1
 python-dateutil ==2.8.1
 pytz            ==2019.2
 requests        ==2.22.0
-suds-jurko      ==0.6
+suds            ==1.0.0
 tornado         ==6.0.3
 tweepy          ==3.8.0
 requests-toolbelt ==0.9.1


### PR DESCRIPTION
- suds-jurko seems to be stalled, with the last release in Jan 24, 2014
- suds seems to be actively mantained again, with the last release in Jun 28, 2022
- I'm putting version 1.0.0 as the minimum, which was released on Dec 05, 2021