### PR TITLE
wolfram|alpha: squash newlines put in returned input

### DIFF
--- a/modules/wolframalpha.py
+++ b/modules/wolframalpha.py
@@ -32,7 +32,7 @@ class Module(ModuleManager.BaseModule):
                 for pod in page["queryresult"]["pods"]:
                     text = pod["subpods"][0]["plaintext"]
                     if pod["id"] == "Input" and text:
-                        input = text
+                        input = text.replace("\n", " | ")
                     elif pod.get("primary", False):
                         primaries.append(text)
 


### PR DESCRIPTION
oddly, wolfram|alpha's returned input string can sometimes contain newlines, especially when asking for distances between locations. previously this caused bitbot's output to get cut off, sending the remaining section to `,more`


```irc
<xfnw> ,wa distance between blåhaj and räv
<testbitbot> [Wolfram|Alpha] distance | from | Blåhø
<xfnw> ,more
<testbitbot> [Wolfram|Alpha] to | Cravo Norte Airport: 8852 km (kilometers)
```

to

```irc
<xfnw> ,wa distance between blåhaj and räv
<testbitbot> [Wolfram|Alpha] distance | from | Blåhø | to | Cravo Norte Airport: 8852 km (kilometers)
```

